### PR TITLE
Fix old eupspkg errors

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -9,9 +9,5 @@ prep()
         FLASK_MAKEFILE="Makefile"
         [ -f ${FLASK_MAKEFILE} ] && mv ${FLASK_MAKEFILE} ${FLASK_MAKEFILE}.eups-removed
 
-        # Remove forgotten .git repository contained in Flask archive
-        # which might break eups
-        FORGOTTEN_GIT_DIR="docs/_themes/.git"
-        [ -e ${FORGOTTEN_GIT_DIR} ] && rm -r ${FORGOTTEN_GIT_DIR}
 }
 


### PR DESCRIPTION
Fixes error where the eupspkg override file returns 1 when attempting to remove an old git directory.